### PR TITLE
Updating AKS provider to work with TF 0.12.0

### DIFF
--- a/k8s/terraform/azure/01-create-aks-cluster/aks-cluster.tf
+++ b/k8s/terraform/azure/01-create-aks-cluster/aks-cluster.tf
@@ -6,7 +6,7 @@ variable "appId" {}
 variable "password" {}
 
 provider "azurerm" {
-  version = "~> 1.20.0"
+  version = "~> 1.27.0"
 }
 
 resource "azurerm_resource_group" "default" {


### PR DESCRIPTION
It appears the version of Terraform in the Azure cloud shell is no longer compatible with the azurerm 1.20.0 provider. This PR updates the version to work with the instructions [here](https://learn.hashicorp.com/consul/getting-started-k8s/azure-k8s).