### PR TITLE
Helm 3 no longer requires helm init

### DIFF
--- a/k8s/terraform/azure/02-fix-k8s-rbac/fix-rbac.tf
+++ b/k8s/terraform/azure/02-fix-k8s-rbac/fix-rbac.tf
@@ -56,9 +56,5 @@ resource "kubernetes_cluster_role_binding" "tiller-cluster-rule" {
     name      = "tiller"
     api_group = ""
   }
-
-  provisioner "local-exec" {
-    command = "helm init --service-account tiller"
-  }
 }
 


### PR DESCRIPTION
Removing that provisioner to run `helm init` as that is no longer required by Helm 3.

This fixes: https://learn.hashicorp.com/consul/kubernetes/azure-k8s