### PR TITLE
dashboard: add two new endpoints to dashboard for Nomad examples

### DIFF
--- a/services/dashboard-service/.gitignore
+++ b/services/dashboard-service/.gitignore
@@ -1,2 +1,3 @@
 rice-box.go
 dist/*
+dashboard-service


### PR DESCRIPTION
The Nomad team is rolling out configuration of Envoy expose paths
for its Consul Connect integration. In Nomad's context, configuring
expose paths allows for "punching a hole" through the network namespace
that Nomad automatically creates for Connect enabled tasks. To demonstrate
this capability, this CR updates the dashboard-service to expose 2
new endpoints. Nomad makes extensive use of these two services throughout
its documentation as a typical example of a Connect setup.

- `/health/api`: provides a real health-check against the connectivity
	with the back-end API service. Consecutive connection failures
	are counted, and if non-zero, the endpoint returns a 503. If
	the most recent connection attempt was success, returns 200.

- `/metrics`: simply exposes Go's built-in `expvar` Handler, which
	produces a JSON response full of Go runtime memory metrics and
	other such data.

The existing endpoints are left as-is.

Example usage:

##### launch counting service
```bash
$ PORT=8888 go run main.go
```

launch dashboard service
```bash
$ PORT=9999 COUNTING_SERVICE_URL='http://localhost:8888' go run main.go
```

##### show `/metrics` endpoint
```bash
$ curl  -s localhost:9999/metrics | jq . | head -n 10
{
  "cmdline": [
    "/tmp/go-build318152207/b001/exe/main"
  ],
  "memstats": {
    "Alloc": 1193440,
    "TotalAlloc": 1193440,
    "Sys": 71387144,
    "Lookups": 0,
    "Mallocs": 2822,
...
```

##### show `/health/api` endpoint with counting service up & running
```bash
$ curl -w '\ncode: %{response_code}\n' -s localhost:9999/health/api
ok
code: 200
```

##### show `/health/api` endpoint with counting service shutdown
```bash
$ curl -w '\ncode: %{response_code}\n' -s localhost:9999/health/api
failures: 3
code: 503
```