### PR TITLE
Fix/build zip

### DIFF
--- a/services/README.md
+++ b/services/README.md
@@ -65,4 +65,4 @@ Requires an installed and configured golang development environment
         +-- dashboard-service_windows_amd64.exe.zip
     ```
 
-- **Clean up build artifacts with `clean.sh`
+- **Clean up build artifacts with `./clean_all`

--- a/services/build_all
+++ b/services/build_all
@@ -8,21 +8,20 @@ cd pkg
 OSES='windows solaris darwin'
 ARCHS='amd64 386'
 OSARCH='!darwin/386'
-gox -os="${OSES}" -arch="${ARCHS}" -osarch="${OSARCH}" ../counting-service ../dashboard-service
+gox -os="${OSES}" -arch="${ARCHS}" -osarch="${OSARCH}" ${SERVICES}
 
 OSES='linux freebsd'
 ARCHS='arm arm64 amd64 386'
-gox -os="${OSES}" -arch="${ARCHS}" ../counting-service ../dashboard-service
+gox -os="${OSES}" -arch="${ARCHS}" ${SERVICES}
 
 FILES=`ls -pd * | grep -v /`
 echo $FILES
 echo "Checksumming and compressing builds..."
-cd zips
 for FILE in ${FILES}
 do
   echo "  ${FILE}..."
-  zip ${FILE}.zip ../${FILE}
-  shasum --algorithm 256 ${FILE}.zip >> SHA256SUMS.txt
+  zip zips/${FILE}.zip ${FILE}
+  shasum --algorithm 256 zips/${FILE}.zip >> zips/SHA256SUMS.txt
 done
 
 cd ${STARTDIR}


### PR DESCRIPTION
The package created from the build script contains the `../` in its content which put the content one directory bellow the expected location when unzipping. The change ensure the service file is in the root location of the zip archive.

_Currently_
```console
$ unzip -l pkg/zips/counting-service_linux_amd64.zip 
Archive:  pkg/zips/counting-service_linux_amd64.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
  6940286  2020-10-01 11:37   ../counting-service_linux_amd64
---------                     -------
  6940286                     1 file
```

_After_
```console
$ unzip -l pkg/zips/counting-service_linux_amd64.zip
Archive:  pkg/zips/counting-service_linux_amd64.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
  6940286  2020-10-01 11:39   counting-service_linux_amd64
---------                     -------
  6940286                     1 file
```