### PR TITLE
fix upstream port for dashboard service config

### DIFF
--- a/demo-config-localhost/dashboard.json
+++ b/demo-config-localhost/dashboard.json
@@ -7,7 +7,7 @@
         "proxy": {
       	  "upstreams": [{
       	    "destination_name": "counting",
-      	    "local_bind_port": 9001
+      	    "local_bind_port": 5000
       	  }]
       	}
       }


### PR DESCRIPTION
Hey, I was trying [this](https://learn.hashicorp.com/tutorials/consul/service-mesh-with-envoy-proxy?in=consul/getting-started) tutorial and found out that proxy port configured in dashboard json is not the same as the one mentioned in tutorial's **dashbord.hcl** file 