### PR TITLE
update from 2 to 3 for AKS node count

### DIFF
--- a/k8s/terraform/azure/01-create-aks-cluster/aks-cluster.tf
+++ b/k8s/terraform/azure/01-create-aks-cluster/aks-cluster.tf
@@ -29,7 +29,7 @@ resource "azurerm_kubernetes_cluster" "default" {
 
   agent_pool_profile {
     name            = "default"
-    count           = 2
+    count           = 3
     vm_size         = "Standard_D2_v2"
     os_type         = "Linux"
     os_disk_size_gb = 30


### PR DESCRIPTION
We recommend and insist on atleast a 3 node K8s cluster for Consul deployment. This is consistent with our GKE/EKS as well as readme for the AKS deployment here.