### PR TITLE
fix: updated Go version to 1.17 and added darwin arm64 support

### DIFF
--- a/services/build_all
+++ b/services/build_all
@@ -1,19 +1,29 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 STARTDIR=`pwd`
-SERVICES="../counting-service ../dashboard-service"
+SERVICES="../counting-service/"
 mkdir -p pkg/zips
-cd pkg
+cd counting-service/
 
-OSES='windows solaris darwin'
+
+OSES='windows solaris'
 ARCHS='amd64 386'
+OSARCH='!darwin/386'
+gox -os="${OSES}" -arch="${ARCHS}" -osarch="${OSARCH}" "${SERVICES}"
+
+
+OSES='darwin'
+ARCHS='amd64 arm64'
 OSARCH='!darwin/386'
 gox -os="${OSES}" -arch="${ARCHS}" -osarch="${OSARCH}" ${SERVICES}
 
+
 OSES='linux freebsd'
 ARCHS='arm arm64 amd64 386'
-gox -os="${OSES}" -arch="${ARCHS}" ${SERVICES}
+gox -os="${OSES}" -arch="${ARCHS}" "${SERVICES}"
 
+mv counting-service* ../pkg/
+cd ../pkg/
 FILES=`ls -pd * | grep -v /`
 echo $FILES
 echo "Checksumming and compressing builds..."
@@ -25,3 +35,33 @@ do
 done
 
 cd ${STARTDIR}
+
+
+cd dashboard-service/
+SERVICES="../dashboard-service/"
+
+OSES='windows solaris'
+ARCHS='amd64 386'
+OSARCH='!darwin/386'
+gox -os="${OSES}" -arch="${ARCHS}" -osarch="${OSARCH}" "${SERVICES}"
+
+OSES='darwin'
+ARCHS='amd64 arm64'
+OSARCH='!darwin/386'
+gox -os="${OSES}" -arch="${ARCHS}" -osarch="${OSARCH}" ${SERVICES}
+
+OSES='linux freebsd'
+ARCHS='arm arm64 amd64 386'
+gox -os="${OSES}" -arch="${ARCHS}" "${SERVICES}"
+
+mv dashboard-service* ../pkg/
+cd ../pkg/
+FILES=`ls -pd * | grep -v /`
+echo $FILES
+echo "Checksumming and compressing builds..."
+for FILE in ${FILES}
+do
+  echo "  ${FILE}..."
+  zip zips/${FILE}.zip ${FILE}
+  shasum --algorithm 256 zips/${FILE}.zip >> zips/SHA256SUMS.txt
+done

--- a/services/counting-service/bin/build
+++ b/services/counting-service/bin/build
@@ -10,8 +10,42 @@ cd dist/linux-amd64
 zip $APPNAME.zip $APPNAME
 cd ../../
 
-# Build for local platform
+# Build linux version
+GOOS=linux GOARCH=arm64 go build -v .
+mkdir -p dist/linux-amd64
+mv $APPNAME dist/linux-amd64/
+cd dist/linux-amd64
+zip $APPNAME.zip $APPNAME
+cd ../../
+
+# Build for Mac OSX (ARM)
+GOOS=darwin GOARCH=arm64 go build -v .
+mkdir -p dist/darwin-amd64
+mv $APPNAME dist/darwin-amd64/
+cd dist/darwin-amd64
+zip $APPNAME.zip $APPNAME
+cd ../../
+
+
+# Build for Mac OSX
 GOOS=darwin GOARCH=amd64 go build -v .
+mkdir -p dist/darwin-amd64
+mv $APPNAME dist/darwin-amd64/
+cd dist/darwin-amd64
+zip $APPNAME.zip $APPNAME
+cd ../../
+
+
+GOOS=windows GOARCH=amd64 go build -v .
+mkdir -p dist/darwin-amd64
+mv $APPNAME dist/darwin-amd64/
+cd dist/darwin-amd64
+zip $APPNAME.zip $APPNAME
+cd ../../
+
+
+# Build for Windows
+GOOS=windows GOARCH=amd64 go build -v .
 mkdir -p dist/darwin-amd64
 mv $APPNAME dist/darwin-amd64/
 cd dist/darwin-amd64

--- a/services/counting-service/go.mod
+++ b/services/counting-service/go.mod
@@ -1,5 +1,5 @@
 module github.com/hashicorp/demo-consul-101/services/counting-service
 
-go 1.15
+go 1.17
 
-require github.com/gorilla/mux v1.8.0 // indirect
+require github.com/gorilla/mux v1.8.0

--- a/services/dashboard-service/go.mod
+++ b/services/dashboard-service/go.mod
@@ -1,10 +1,11 @@
 module github.com/hashicorp/demo-consul-101/services/dashboard-service
 
-go 1.15
+go 1.17
 
 require (
-	github.com/GeertJohan/go.rice v1.0.2 // indirect
-	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/GeertJohan/go.rice v1.0.2
+	github.com/gorilla/mux v1.8.0
+	github.com/graarh/golang-socketio v0.0.0-20170510162725-2c44953b9b5f
+	github.com/daaku/go.zipexe v1.0.1 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
-	github.com/graarh/golang-socketio v0.0.0-20170510162725-2c44953b9b5f // indirect
 )

--- a/services/dashboard-service/go.sum
+++ b/services/dashboard-service/go.sum
@@ -2,8 +2,9 @@ github.com/GeertJohan/go.incremental v1.0.0/go.mod h1:6fAjUhbVuX1KcMD3c8TEgVUqmo
 github.com/GeertJohan/go.rice v1.0.2 h1:PtRw+Tg3oa3HYwiDBZyvOJ8LdIyf6lAovJJtr7YOAYk=
 github.com/GeertJohan/go.rice v1.0.2/go.mod h1:af5vUNlDNkCjOZeSGFgIJxDje9qdjsO6hshx0gTmZt4=
 github.com/akavel/rsrc v0.8.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
-github.com/daaku/go.zipexe v1.0.0 h1:VSOgZtH418pH9L16hC/JrgSNJbbAL26pj7lmD1+CGdY=
 github.com/daaku/go.zipexe v1.0.0/go.mod h1:z8IiR6TsVLEYKwXAoE/I+8ys/sDkgTzSL0CLnGVd57E=
+github.com/daaku/go.zipexe v1.0.1 h1:wV4zMsDOI2SZ2m7Tdz1Ps96Zrx+TzaK15VbUaGozw0M=
+github.com/daaku/go.zipexe v1.0.1/go.mod h1:5xWogtqlYnfBXkSB1o9xysukNP9GTvaNkqzUZbt3Bw8=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=


### PR DESCRIPTION
This PR updates the Go version to 1.17. Support for Darwin `arm64` was also added.